### PR TITLE
consider padding for the CoSE-Bilkent layout

### DIFF
--- a/src/Layout/index.js
+++ b/src/Layout/index.js
@@ -304,12 +304,12 @@ _CoSELayout.prototype.processChildrenList = function (parent, children, layout) 
     var children_of_children = theChild.children();
     var theNode;
 
-    if (theChild.width() != null
-            && theChild.height() != null) {
+    if (theChild.outerWidth() != null
+            && theChild.outerHeight() != null) {
       theNode = parent.add(new CoSENode(layout.graphManager,
-              new PointD(theChild.position('x') - theChild.width() / 2, theChild.position('y') - theChild.height() / 2),
-              new DimensionD(parseFloat(theChild.width()),
-                      parseFloat(theChild.height()))));
+              new PointD(theChild.position('x') - theChild.outerWidth() / 2, theChild.position('y') - theChild.outerHeight() / 2),
+              new DimensionD(parseFloat(theChild.outerWidth()),
+                      parseFloat(theChild.outerHeight()))));
     }
     else {
       theNode = parent.add(new CoSENode(this.graphManager));
@@ -317,10 +317,10 @@ _CoSELayout.prototype.processChildrenList = function (parent, children, layout) 
     // Attach id to the layout node
     theNode.id = theChild.data("id");
     // Attach the paddings of cy node to layout node
-    theNode.paddingLeft = parseInt( theChild.css('padding-left') );
-    theNode.paddingTop = parseInt( theChild.css('padding-top') );
-    theNode.paddingRight = parseInt( theChild.css('padding-right') );
-    theNode.paddingBottom = parseInt( theChild.css('padding-bottom') );
+    theNode.paddingLeft = parseInt( theChild.css('padding') );
+    theNode.paddingTop = parseInt( theChild.css('padding') );
+    theNode.paddingRight = parseInt( theChild.css('padding') );
+    theNode.paddingBottom = parseInt( theChild.css('padding') );
     // Map the layout node
     this.idToLNode[theChild.data("id")] = theNode;
 


### PR DESCRIPTION
- call outerWidth() and outerHeight() instead of height() and width().
  This ensures that padding is accounted for in the layout.
- use a singular padding value for all of (paddingRight, paddingLeft,
  paddingTop, paddingBottom).  padding has been changed to a single
value for each of left, right, top, bottom in cy.js 3.x @maxkfranz correct me if I am wrong

Related to: https://github.com/cytoscape/cytoscape.js-cose-bilkent/issues/42

### Notes
Not sure if anything else needs to change. @metincansiper feel free to comment or continue to add onto this commit/branch if you see anything that does need to change.  

Seems to produce much better results now in cases where nodes have padding.

### Before

![graph23157196](https://user-images.githubusercontent.com/2328291/27596783-94c7a2b6-5b2e-11e7-81d9-84374060dc71.png)


### After

![graph92891413](https://user-images.githubusercontent.com/2328291/27596794-9b810b1a-5b2e-11e7-8ec2-26b57c5e260a.png)
