### PR TITLE
Add the option to include labels in node dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ var defaultOptions = {
   // Called on `layoutstop`
   stop: function () {
   },
+  // Whether to include labels in node dimensions. Useful for avoiding label overlap
+  nodeDimensionsIncludeLabels: false,
   // number of ticks per frame; higher is faster but more jerky
   refresh: 30, 
   // Whether to fit the network view after when done

--- a/src/Layout/LNode.js
+++ b/src/Layout/LNode.js
@@ -300,6 +300,28 @@ LNode.prototype.updateBounds = function () {
 
     this.setWidth(childGraph.getRight() - childGraph.getLeft());
     this.setHeight(childGraph.getBottom() - childGraph.getTop());
+    
+    // Update compound bounds considering its label properties    
+    if(LayoutConstants.NODE_DIMENSIONS_INCLUDE_LABELS){
+        
+      var width = childGraph.getRight() - childGraph.getLeft();
+      var height = childGraph.getBottom() - childGraph.getTop();
+
+      if(this.labelWidth > width){
+        this.rect.x -= (this.labelWidth - width) / 2;
+        this.setWidth(this.labelWidth);
+      }
+
+      if(this.labelHeight > height){
+        if(this.labelPos == "center"){
+          this.rect.y -= (this.labelHeight - height) / 2;
+        }
+        else if(this.labelPos == "top"){
+          this.rect.y -= (this.labelHeight - height); 
+        }
+        this.setHeight(this.labelHeight);
+      }
+    }
   }
 };
 

--- a/src/Layout/LayoutConstants.js
+++ b/src/Layout/LayoutConstants.js
@@ -29,6 +29,11 @@ LayoutConstants.DEFAULT_UNIFORM_LEAF_NODE_SIZES = false;
 LayoutConstants.DEFAULT_GRAPH_MARGIN = 15;
 
 /*
+ * Whether to consider labels in node dimensions or not
+ */
+LayoutConstants.NODE_DIMENSIONS_INCLUDE_LABELS = false;
+
+/*
  * Default dimension of a non-compound node.
  */
 LayoutConstants.SIMPLE_NODE_SIZE = 40;

--- a/src/Layout/index.js
+++ b/src/Layout/index.js
@@ -38,7 +38,7 @@ var defaults = {
   stop: function () {
   },
   // include labels in node dimensions
-  nodeDimensionsIncludeLabels: true,
+  nodeDimensionsIncludeLabels: false,
   // number of ticks per frame; higher is faster but more jerky
   refresh: 30,
   // Whether to fit the network view after when done

--- a/src/Layout/index.js
+++ b/src/Layout/index.js
@@ -37,6 +37,8 @@ var defaults = {
   // Called on `layoutstop`
   stop: function () {
   },
+  // include labels in node dimensions
+  nodeDimensionsIncludeLabels: true,
   // number of ticks per frame; higher is faster but more jerky
   refresh: 30,
   // Whether to fit the network view after when done
@@ -310,14 +312,17 @@ _CoSELayout.prototype.processChildrenList = function (parent, children, layout) 
     var theChild = children[i];
     this.options.eles.nodes().length;
     var children_of_children = theChild.children();
-    var theNode;
+    var theNode;    
+
+    var dimensions = theChild.layoutDimensions({
+      nodeDimensionsIncludeLabels: this.options.nodeDimensionsIncludeLabels
+    });
 
     if (theChild.outerWidth() != null
             && theChild.outerHeight() != null) {
       theNode = parent.add(new CoSENode(layout.graphManager,
-              new PointD(theChild.position('x') - theChild.outerWidth() / 2, theChild.position('y') - theChild.outerHeight() / 2),
-              new DimensionD(parseFloat(theChild.outerWidth()),
-                      parseFloat(theChild.outerHeight()))));
+              new PointD(theChild.position('x') - dimensions.w / 2, theChild.position('y') - dimensions.h / 2),
+              new DimensionD(parseFloat(dimensions.w), parseFloat(dimensions.h))));
     }
     else {
       theNode = parent.add(new CoSENode(this.graphManager));

--- a/src/Layout/index.js
+++ b/src/Layout/index.js
@@ -120,6 +120,7 @@ var getUserOptions = function (options) {
   if (options.initialEnergyOnIncremental != null)
     CoSEConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL = FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL = options.initialEnergyOnIncremental;
 
+  CoSEConstants.NODE_DIMENSIONS_INCLUDE_LABELS = FDLayoutConstants.NODE_DIMENSIONS_INCLUDE_LABELS = LayoutConstants.NODE_DIMENSIONS_INCLUDE_LABELS = options.nodeDimensionsIncludeLabels;
   CoSEConstants.DEFAULT_INCREMENTAL = FDLayoutConstants.DEFAULT_INCREMENTAL = LayoutConstants.DEFAULT_INCREMENTAL =
           !(options.randomize);
   CoSEConstants.ANIMATE = FDLayoutConstants.ANIMATE = LayoutConstants.ANIMATE = options.animate;
@@ -334,6 +335,19 @@ _CoSELayout.prototype.processChildrenList = function (parent, children, layout) 
     theNode.paddingTop = parseInt( theChild.css('padding') );
     theNode.paddingRight = parseInt( theChild.css('padding') );
     theNode.paddingBottom = parseInt( theChild.css('padding') );
+    
+    //Attach the label properties to compound if labels will be included in node dimensions  
+    if(this.options.nodeDimensionsIncludeLabels){
+      if(theChild.isParent()){
+          var labelWidth = theChild.boundingBox({ includeLabels: true, includeNodes: false }).w;          
+          var labelHeight = theChild.boundingBox({ includeLabels: true, includeNodes: false }).h;
+          var labelPos = theChild.css("text-halign");
+          theNode.labelWidth = labelWidth;
+          theNode.labelHeight = labelHeight;
+          theNode.labelPos = labelPos;
+      }
+    }
+    
     // Map the layout node
     this.idToLNode[theChild.data("id")] = theNode;
 


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/2328291/29287728-76b43ebe-8104-11e7-8ccd-3c876ab4cb9e.png)

After:
![after](https://user-images.githubusercontent.com/2328291/29287864-af47d6aa-8104-11e7-8b41-1bb79ef1d03f.png)


@maxkfranz  @ugurdogrusoz @hasanbalci @kinimesi @metincansiper 

### Considerations
- This option may conflict with the tiling functionality so I set this option to false by default but I think it is clear that this makes the layout results much better when you have long labels.