### PR TITLE
Allow stopping for `animate:true`

### DIFF
--- a/src/Layout/index.js
+++ b/src/Layout/index.js
@@ -139,6 +139,8 @@ _CoSELayout.prototype.run = function () {
   var layout = this.layout = new CoSELayout();
   var self = this;
   
+  self.stopped = false;
+
   this.cy = this.options.cy;
 
   this.cy.trigger({ type: 'layoutstart', layout: this });
@@ -195,7 +197,7 @@ _CoSELayout.prototype.run = function () {
     var isDone;
 
     for( var i = 0; i < ticksPerFrame && !isDone; i++ ){
-      isDone = self.layout.tick();
+      isDone = self.stopped || self.layout.tick();
     }
     
     // If layout is done
@@ -372,8 +374,6 @@ _CoSELayout.prototype.processChildrenList = function (parent, children, layout) 
  */
 _CoSELayout.prototype.stop = function () {
   this.stopped = true;
-  
-  this.trigger('layoutstop');
 
   return this; // chaining
 };


### PR DESCRIPTION
- Check whether manually stopped before each tick
- Reset flag on `run()`, in case layout is reused
- Don't emit `layoutstop` in `stop()` -- the tick loop handles this
  after some postprocessing

Addresses 

> Calling .stop() on the layout doesn't stop the layout/animation #58