### PR TITLE
Automatically update copyright year spans in LICENSE

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) Cytoscape Consortium
+
+
+Copyright (c) 2016-2018, The Cytoscape Consortium.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ N.b. all builds use babel, so modern ES features can be used in the `src`.
 
 This project is set up to automatically be published to npm and bower.  To publish:
 
-1. Build the extension : `npm run build`
+1. Build the extension : `npm run build:release`
 1. Commit the build : `git commit -am "Build for release"`
 1. Bump the version number and tag: `npm version major|minor|patch`
 1. Push to origin: `git push && git push --tags`

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "gh-pages:demo": "cpy demo.html . --rename=index.html",
     "gh-pages:deploy": "gh-pages -d .",
     "gh-pages:clean": "rimraf index.html",
+    "copyright": "update license",
     "lint": "eslint src",
     "build": "cross-env NODE_ENV=production webpack",
     "build:min": "cross-env NODE_ENV=production MIN=true webpack",
+    "build:release": "run-s build copyright",
     "watch": "webpack --progress --watch",
     "dev": "webpack-dev-server --open",
     "test": "mocha"
@@ -34,19 +36,20 @@
     "babel-preset-env": "^1.5.1",
     "camelcase": "^4.1.0",
     "chai": "4.0.2",
+    "cpy-cli": "^1.0.1",
     "cross-env": "^5.0.0",
     "eslint": "^3.9.1",
-    "mocha": "3.4.2",
-    "webpack": "^2.6.1",
-    "webpack-dev-server": "^2.4.5",
-    "cpy-cli": "^1.0.1",
-    "npm-run-all": "^4.1.2",
     "gh-pages": "^1.0.0",
-    "rimraf": "^2.6.2"
+    "mocha": "3.4.2",
+    "npm-run-all": "^4.1.2",
+    "rimraf": "^2.6.2",
+    "update": "^0.7.4",
+    "updater-license": "^1.0.0",
+    "webpack": "^2.6.1",
+    "webpack-dev-server": "^2.4.5"
   },
   "peerDependencies": {
     "cytoscape": "^3.2.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
This PR updates the npm scripts to automatically update the copyright year spans (e.g. 2016-2018) in the MIT LICENSE file.  It uses the `copyright` npm script, which is used in `build:release`.  That means the year span gets updated automatically each time a new release of the extension is published.

If you want to try it out for yourself to verify it's working:

1. Modify LICENSE to `2016-2017`
1. Run `npm run copyright`
1. View LICENSE (e.g. `less LICENSE`) and note that the span is updated to `2016-2018`

This is a new (dev) feature, so I suppose it would require a minor version bump (i.e. `npm version minor`).  This doesn't really need to be published right away, so you might want to bundle it with other changes if you're planning a new release within the next few weeks.