### PR TITLE
Ignore node_modules in gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "postpublish": "run-s gh-pages:demo gh-pages:deploy gh-pages:clean",
     "gh-pages:demo": "cpy demo.html . --rename=index.html",
-    "gh-pages:deploy": "gh-pages -d .",
+    "gh-pages:deploy": "gh-pages -d . -v node_modules/**",
     "gh-pages:clean": "rimraf index.html",
     "copyright": "update license",
     "lint": "eslint src",


### PR DESCRIPTION
This improves the stability of the `gh-pages:deploy` target.