### PR TITLE
Revise gh-pages publishing to better ignore node_modules dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 npm-debug.log
-index.html
 package-lock.json
 nbproject/*

--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
   "description": "The CoSE layout for Cytoscape.js by Bilkent with enhanced compound node placement",
   "main": "cytoscape-cose-bilkent.js",
   "scripts": {
-    "postpublish": "run-s gh-pages:demo gh-pages:deploy gh-pages:clean",
-    "gh-pages:demo": "cpy demo.html . --rename=index.html",
-    "gh-pages:deploy": "gh-pages -d . -v node_modules/**",
-    "gh-pages:clean": "rimraf index.html",
+    "postpublish": "run-s gh-pages",
+    "gh-pages": "gh-pages -d pages",
     "copyright": "update license",
     "lint": "eslint src",
     "build": "cross-env NODE_ENV=production webpack",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "postpublish": "run-s gh-pages:demo gh-pages:deploy gh-pages:clean",
     "gh-pages:demo": "cpy demo.html . --rename=index.html",
-    "gh-pages:deploy": "gh-pages -d .",
+    "gh-pages:deploy": "gh-pages -d . -v node_modules/**",
     "gh-pages:clean": "rimraf index.html",
     "copyright": "update license",
     "lint": "eslint src",

--- a/pages/cytoscape-cose-bilkent.js
+++ b/pages/cytoscape-cose-bilkent.js
@@ -1,0 +1,1 @@
+../cytoscape-cose-bilkent.js

--- a/pages/demo-compound.html
+++ b/pages/demo-compound.html
@@ -1,0 +1,1 @@
+../demo-compound.html

--- a/pages/demo.html
+++ b/pages/demo.html
@@ -1,0 +1,1 @@
+../demo.html

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,1 @@
+../demo.html


### PR DESCRIPTION


This uses a separate 'pages' dir with symlinks in it.  Anything in the 'pages' dir gets published.  Some versions of the 'gh-pages' module include node_modules no matter what options are specified.  Using the separate directory avoids this issue.